### PR TITLE
ptt-fix: fix tight loop on keyboard un-plugging or re-plugging

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -88,7 +88,7 @@ func (lis *Listener) listen(ctx context.Context) (retry bool, err error) {
 			}
 
 			logger.Warn("read event", errKey, err)
-			continue
+			return true, err
 		}
 
 		if !ev.Is(evdev.EvKey, lis.Keycode) {


### PR DESCRIPTION
Currently when the keyboard is unlugged, ptt-fix starts eating CPU cycles and flooding with tons of warnings like this.

```
Dec 14 19:17:59.716 WARN read event
        device=/dev/input/by-id/usb-Hoksi_Technology_DURGOD_Taurus_K310__QMK_-if02-event-kbd
        err="read: read /dev/input/by-id/usb-Hoksi_Technology_DURGOD_Taurus_K310__QMK_-if02-event-kbd: no such device"
Dec 14 19:17:59.716 WARN read event
        device=/dev/input/by-id/usb-Hoksi_Technology_DURGOD_Taurus_K310__QMK_-if02-event-kbd
        err="read: read /dev/input/by-id/usb-Hoksi_Technology_DURGOD_Taurus_K310__QMK_-if02-event-kbd: no such device"
...
and so on
```

This change makes it work fine on both unplugging and re-plugging the keyboard.